### PR TITLE
Update su_posts templates: hide comments link like wp the themes

### DIFF
--- a/templates/default-loop.php
+++ b/templates/default-loop.php
@@ -19,8 +19,9 @@
 				<div class="su-post-excerpt">
 					<?php the_excerpt(); ?>
 				</div>
-
+				<?php if ( comments_open() ) : ?>
 				<a href="<?php comments_link(); ?>" class="su-post-comments-link"><?php comments_number( __( '0 comments', 'shortcodes-ultimate' ), __( '1 comment', 'shortcodes-ultimate' ), '% comments' ); ?></a>
+			<?php endif; ?>
 
 			</div>
 

--- a/templates/default-loop.php
+++ b/templates/default-loop.php
@@ -19,9 +19,10 @@
 				<div class="su-post-excerpt">
 					<?php the_excerpt(); ?>
 				</div>
-				<?php if ( comments_open() ) : ?>
-				<a href="<?php comments_link(); ?>" class="su-post-comments-link"><?php comments_number( __( '0 comments', 'shortcodes-ultimate' ), __( '1 comment', 'shortcodes-ultimate' ), '% comments' ); ?></a>
-			<?php endif; ?>
+
+				<?php if ( have_comments() || comments_open() ) : ?>
+					<a href="<?php comments_link(); ?>" class="su-post-comments-link"><?php comments_number( __( '0 comments', 'shortcodes-ultimate' ), __( '1 comment', 'shortcodes-ultimate' ), '% comments' ); ?></a>
+				<?php endif; ?>
 
 			</div>
 

--- a/templates/single-post.php
+++ b/templates/single-post.php
@@ -15,7 +15,7 @@
 					<div id="su-post-<?php the_ID(); ?>" class="su-post">
 						<h1 class="su-post-title"><?php the_title(); ?></h1>
 						<div class="su-post-meta"><?php _e( 'Posted', 'shortcodes-ultimate' ); ?>: <?php the_time( get_option( 'date_format' ) ); ?>
-						<?php if ( comments_open() ) : ?>
+						<?php if ( have_comments() || comments_open() ) : ?>
 							 | <a href="<?php comments_link(); ?>" class="su-post-comments-link"><?php comments_number( __( '0 comments', 'shortcodes-ultimate' ), __( '1 comment', 'shortcodes-ultimate' ), __( '%n comments', 'shortcodes-ultimate' ) ); ?></a>
 						<?php endif; ?>
 						</div>

--- a/templates/single-post.php
+++ b/templates/single-post.php
@@ -14,7 +14,11 @@
 					?>
 					<div id="su-post-<?php the_ID(); ?>" class="su-post">
 						<h1 class="su-post-title"><?php the_title(); ?></h1>
-						<div class="su-post-meta"><?php _e( 'Posted', 'shortcodes-ultimate' ); ?>: <?php the_time( get_option( 'date_format' ) ); ?> | <a href="<?php comments_link(); ?>" class="su-post-comments-link"><?php comments_number( __( '0 comments', 'shortcodes-ultimate' ), __( '1 comment', 'shortcodes-ultimate' ), __( '%n comments', 'shortcodes-ultimate' ) ); ?></a></div>
+						<div class="su-post-meta"><?php _e( 'Posted', 'shortcodes-ultimate' ); ?>: <?php the_time( get_option( 'date_format' ) ); ?>
+						<?php if ( comments_open() ) : ?>
+							 | <a href="<?php comments_link(); ?>" class="su-post-comments-link"><?php comments_number( __( '0 comments', 'shortcodes-ultimate' ), __( '1 comment', 'shortcodes-ultimate' ), __( '%n comments', 'shortcodes-ultimate' ) ); ?></a>
+						<?php endif; ?>
+						</div>
 						<div class="su-post-content">
 							<?php the_content(); ?>
 						</div>


### PR DESCRIPTION
Only show comment link if comments are open or exist.

This will only show the comment link when it's relevant for the user – if he can either read or write comments. 
Works well with [Disable Comments](https://wordpress.org/plugins/disable-comments/).

I'd be glad if this gets merged!
kind regads